### PR TITLE
Create server for Matrix redirect

### DIFF
--- a/.well-known/matrix/server
+++ b/.well-known/matrix/server
@@ -1,0 +1,1 @@
+{"m.server":"synapse.kossiitkgp.org:443"}


### PR DESCRIPTION
Needed for redirection of Matrix clients from kossiitkgp.org to synapse.kossiitkgp.org where it's actually hosted.

More info: https://matrix-org.github.io/synapse/latest/delegate.html